### PR TITLE
Add launchers for software with no default menu representation

### DIFF
--- a/personas/clinician/clinician.sh
+++ b/personas/clinician/clinician.sh
@@ -24,11 +24,41 @@ wget http://slicer.kitware.com/midas3/download/bitstream/738960/Slicer-4.8.1-lin
 tar xvf Slicer-4.8.1-linux-amd64.tar.gz
 rm Slicer-4.8.1-linux-amd64.tar.gz
 mv Slicer-4.8.1-linux-amd64/ Slicer-Dicom-Viewer
+wget https://www.slicer.org/w/images/0/05/Logo-3DSlicer.png -O /usr/share/pixmaps/slicer.png
+echo "
+[Desktop Entry]
+Name=Slicer
+Comment=
+Exec=/home/`whoami`/Desktop/Slicer-Dicom-Viewer/Slicer
+Icon=/usr/share/pixmaps/slicer.png
+Terminal=false
+Type=Graphics
+" >> /usr/share/applications/slicer.desktop
 
 sudo npm install nativefier -g
 
 # [resource] NIH PubMed: Comprises more than 28 million citations for biomedical literature from MEDLINE, life science journals, and online books.
 nativefier --name "NIH Pubmed" "https://www.ncbi.nlm.nih.gov/pubmed/"
+wget https://www.nlm.nih.gov/about/logos_nlm_photos/pubmed_logo.png -O /usr/share/pixmaps/nih-pubmed.png
+echo "
+[Desktop Entry]
+Name=Pubmed
+Comment=
+Exec=/home/`whoami`/Desktop/nih-pubmed-linux-x64/nih-pubmed
+Icon=/usr/share/pixmaps/nih-pubmed.png
+Terminal=false
+Type=Internet
+" >> /usr/share/applications/pubmed.desktop
 
 # [resource] MedScape: Medical news, thought leader perspectives, clinical trial coverage, drug updates, journal articles, CME activities & more.
 nativefier --name "Medscape Reference" "https://reference.medscape.com/"
+wget https://upload.wikimedia.org/wikipedia/commons/thumb/1/14/Medscape_Logo.svg/320px-Medscape_Logo.svg.png -O /usr/share/pixmaps/medscape.png
+echo "
+[Desktop Entry]
+Name=Medscape
+Comment=
+Exec=/home/`whoami`/Desktop/medscape-reference-linux-x64/medscape-reference
+Icon=/usr/share/pixmaps/medscape.png
+Terminal=false
+Type=Internet
+" >> /usr/share/applications/medscape.desktop

--- a/personas/creative/creative.sh
+++ b/personas/creative/creative.sh
@@ -141,8 +141,17 @@ sudo dpkg -i helm_0.9.0_amd64_r.deb
 rm helm_0.9.0_amd64_r.deb
 
 # [package] Giada: A compact and portable virtual loop machine device for Linux, Mac and Window.
-wget https://www.giadamusic.com/data/Giada-0.15.2-x86_64.AppImage
-
+wget https://www.giadamusic.com/data/Giada-0.15.2-x86_64.AppImage -O /usr/local/bin/giada
+wget https://github.com/monocasual/giada/raw/2a3496ac4c0a546974030e7135f21aaf218af7e0/extras/giada-logo.png -O /usr/share/pixmaps/giada.png
+echo '
+[Desktop Entry]
+Name=Giada
+Comment=
+Exec=/usr/local/bin/giada
+Icon=/usr/share/pixmaps/giada.png
+Terminal=false
+Type=Multimedia
+' >> /usr/share/applications/giada.desktop
 
 # TODO:
 # http://linuxsampler.org/

--- a/personas/engineer/engineer.sh
+++ b/personas/engineer/engineer.sh
@@ -992,6 +992,8 @@ git clone https://github.com/facebook/create-react-app.git
 # [package] jRegExAnalyser: An interactive tool to write, test, debug, analyse and profile regular expressions. 
 wget http://jregexanalyser.schwebke.com/jregexanalyser/jRegExAnalyser-1_4_0.zip
 unzip jRegExAnalyser-1_4_0.zip
+./jRegExAnalyser-1_4_0/jregexanalyser
+./jRegExAnalyser-1_4_0/jregexanalyser-install
 rm jRegExAnalyser-1_4_0.zip
 
 # [package] Spring Tool Suite: An extended IDE of Eclipse. It specializes in developing Spring applications. 


### PR DESCRIPTION
@MatthewVi 

I put the logos for the software under `/usr/share/pixmaps/` and left everything else on the Desktop (apart from Giada which I put under `/usr/local/bin`). 

Anyway, have a look and let me know your thoughts. 